### PR TITLE
Add `--discogs` argument, fetch metadata from Discogs.com

### DIFF
--- a/cmd/id3ed/main.go
+++ b/cmd/id3ed/main.go
@@ -4,8 +4,13 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/lukasschwab/id3ed/pkg/meta"
+
+	"github.com/irlndts/go-discogs"
 )
 
 func open(filename string) *meta.Meta {
@@ -40,10 +45,39 @@ func editMetadata(filename string, partial *meta.Partial, comment bool) {
 	log.Printf("Updated metadata.")
 }
 
+func getDiscogsMeta(releaseID string) *meta.Partial {
+	id, err := strconv.Atoi(regexp.MustCompile(`\d+`).FindString(releaseID))
+	if err != nil {
+		log.Printf("No valid release ID in '%v'", releaseID)
+		return &meta.Partial{}
+	}
+	client, err := discogs.New(&discogs.Options{
+		UserAgent: "id3ed +github.com/lukasschwab/id3ed",
+	})
+	if err != nil {
+		log.Printf("Error constructing Discogs client: %v", err)
+		return &meta.Partial{}
+	}
+	release, err := client.Release(id)
+	if err != nil {
+		log.Printf("Couldn't get Discogs release '%v': %v", id, err)
+		return &meta.Partial{}
+	}
+	year := strconv.Itoa(release.Year)
+	genre := strings.Join(release.Genres, ", ")
+	return &meta.Partial{
+		Artist: &release.ArtistsSort,
+		Album:  &release.Title,
+		Year:   &year,
+		Genre:  &genre,
+	}
+}
+
 func main() {
 	// TODO: take settable fields as named arguments.
 	inspect := flag.Bool("inspect", false, "print current file metadata")
 	// Editor options.
+	discogsID := flag.String("discogs", "", "Discogs.com release (ID or URL) to pre-fill")
 	partial := &meta.Partial{
 		Title:  flag.String("title", "", "title to pre-fill"),
 		Artist: flag.String("artist", "", "artist to pre-fill"),
@@ -59,6 +93,11 @@ func main() {
 	if *inspect {
 		inspectMetadata(filename)
 		return
+	}
+
+	if discogsID != nil {
+		discogsMeta := getDiscogsMeta(*discogsID)
+		partial.Mask(discogsMeta)
 	}
 
 	editMetadata(filename, partial, *comment)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/lukasschwab/id3ed
 go 1.17
 
 require (
-	github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da // indirect
-	github.com/mikkyang/id3-go v0.0.0-20191012064224-2c6ab3bb1fbd // indirect
-	github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5 // indirect
+	github.com/irlndts/go-discogs v0.3.5
+	github.com/mikkyang/id3-go v0.0.0-20191012064224-2c6ab3bb1fbd
+	github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5
 )
+
+require github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
 github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da h1:0qwwqQCLOOXPl58ljnq3sTJR7yRuMolM02vjxDh4ZVE=
 github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da/go.mod h1:ns+zIWBBchgfRdxNgIJWn2x6U95LQchxeqiN5Cgdgts=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/irlndts/go-discogs v0.3.5 h1:tVx1kLlrWMN7OfwTZ8OCCWQIICdyklBC0ojn5QJZwDY=
+github.com/irlndts/go-discogs v0.3.5/go.mod h1:UVQ05FdCzH4P/usnSxQDh77QYE37HvmPnSCgogioljo=
 github.com/mikkyang/id3-go v0.0.0-20191012064224-2c6ab3bb1fbd h1:Cqivkwpk34qJJsi0xbZp2TOhpMsG381iaum8mb+6T/s=
 github.com/mikkyang/id3-go v0.0.0-20191012064224-2c6ab3bb1fbd/go.mod h1:6ReX25kzt2D67Dt9vH3kTm8R4luFEfW9W3RDuytp0IA=
 github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5 h1:erxeiTyq+nw4Cz5+hLDkOwNF5/9IQWCQPv0gpb3+QHU=
 github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Changes

Adds a `--discogs` argument which accepts either

+ A Discogs release URL: https://www.discogs.com/release/9421095-Junko-Yagami-Lonely-Girl
+ A Discogs release ID: 9421095
+ (Any string where the leftmost `\d+` match is a discogs ID)

Populates a `partial`, then folds it into the partial defined by user inputs *preferring the user inputs.*

Can move this into some `pkg/discogs` if main.go is getting too busy.

## Motivation

+ Fix #1 